### PR TITLE
BF: Sending clock.now() into the push_sample call will cause the rece…

### DIFF
--- a/smile/lsl.py
+++ b/smile/lsl.py
@@ -129,9 +129,9 @@ class LSLPush(CallbackState):
 
     def _callback(self):
         if type(self._push_val) != list:
-            self._server.push_sample([self._push_val], clock.now())
+            self._server.push_sample([self._push_val])
         else:
-            self._server.push_sample(self._push_val, clock.now())
+            self._server.push_sample(self._push_val)
         self._push_time = clock.now()
 
 


### PR DESCRIPTION
…iving end to log that time as the time it received a pulse. This causes all of the data to become unaligned