### PR TITLE
UPDATE: Python3

### DIFF
--- a/smile/audio.py
+++ b/smile/audio.py
@@ -10,8 +10,8 @@
 import os
 import time
 
-from state import Wait
-from clock import clock
+from .state import Wait
+from .clock import clock
 
 # add in system site-packages if necessary
 try:
@@ -453,8 +453,8 @@ class RecordSoundFile(Wait):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import Parallel, Wait, Serial, Meanwhile, UntilDone, Loop
+    from .experiment import Experiment
+    from .state import Parallel, Wait, Serial, Meanwhile, UntilDone, Loop
 
     exp = Experiment()
 

--- a/smile/clock.py
+++ b/smile/clock.py
@@ -1,4 +1,4 @@
-import kivy_overrides
+import smile.kivy_overrides as kivy_overrides
 import kivy.clock
 
 _get_time = kivy.clock._default_time

--- a/smile/common.py
+++ b/smile/common.py
@@ -8,8 +8,8 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 # SMILE components
-from experiment import Experiment
-from state import (
+from .experiment import Experiment
+from .state import (
     Parallel,
     Meanwhile,
     UntilDone,
@@ -29,15 +29,15 @@ from state import (
     ResetClock,
     Debug,
     PrintTraceback)
-from keyboard import Key, KeyPress, KeyRecord
-from mouse import (
+from .keyboard import Key, KeyPress, KeyRecord
+from .mouse import (
     MouseWithin,
     MousePos,
     MouseButton,
     MouseCursor,
     MouseRecord,
     MousePress)
-from video import (
+from .video import (
     Screenshot,
     Bezier,
     Mesh,
@@ -76,10 +76,10 @@ from video import (
     Animate,
     BlockingFlips,
     NonBlockingFlips)
-from dotbox import DotBox, DynamicDotBox
-from moving_dots import MovingDots
-from grating import Grating
-from ref import Ref, val, jitter, shuffle
+from .dotbox import DotBox, DynamicDotBox
+from .moving_dots import MovingDots
+from .grating import Grating
+from .ref import Ref, val, jitter, shuffle
 #from smile.audio import Beep, SoundFile, RecordSoundFile
-from freekey import FreeKey
-from questionnaire import Questionnaire
+from .freekey import FreeKey
+from .questionnaire import Questionnaire

--- a/smile/demographics.py
+++ b/smile/demographics.py
@@ -1,4 +1,4 @@
-from smile.common import *
+from common import *
 
 # Standard Demographics Logging
 

--- a/smile/dotbox.py
+++ b/smile/dotbox.py
@@ -7,10 +7,10 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from video import WidgetState, BlockingFlips, NonBlockingFlips
-from state import Wait, Meanwhile, Parallel, Loop, Subroutine
-from state import If, Else
-from ref import jitter
+from .video import WidgetState, BlockingFlips, NonBlockingFlips
+from .state import Wait, Meanwhile, Parallel, Loop, Subroutine
+from .state import If, Else
+from .ref import jitter
 
 from kivy.uix.widget import Widget
 from kivy.properties import NumericProperty, ListProperty
@@ -42,7 +42,7 @@ class DotBox(Widget):
     pointsize = NumericProperty(5)
 
     def __init__(self, **kwargs):
-        super(type(self), self).__init__(**kwargs)
+        super(type(self), self).__init__()
 
         self._color = None
         self._backcolor = None
@@ -63,7 +63,7 @@ class DotBox(Widget):
 
     def _update_locs(self, *pargs):
         self._locs = [random.random()
-                      for i in xrange(int(self.num_dots)*2)]
+                      for i in range(int(self.num_dots)*2)]
         self._update()
 
     def _update_pointsize(self, *pargs):
@@ -155,8 +155,8 @@ def DynamicDotBox(self, duration=None,
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import UntilDone, Serial
+    from .experiment import Experiment
+    from .state import UntilDone, Serial
 
     exp = Experiment(background_color="#330000")
 

--- a/smile/experiment.py
+++ b/smile/experiment.py
@@ -15,18 +15,22 @@ import time
 import threading
 
 # kivy imports
-import kivy_overrides
+import smile.kivy_overrides as kivy_overrides
 import kivy
 import kivy.base
 from kivy.utils import platform
 import kivy.clock
 
 # local imports
-from state import Serial, AutoFinalizeState
-from ref import Ref
-from clock import clock
-from log import LogWriter, log2csv
-from event import event_time
+from .state import Serial, AutoFinalizeState
+from .ref import Ref
+from .clock import clock
+from .log import LogWriter, log2csv
+from .event import event_time
+
+#--EDITED 6.14.18--
+#from state import StateClass
+
 
 _kivy_clock = kivy.clock.Clock
 
@@ -455,7 +459,8 @@ class Experiment(object):
                                                     time.gmtime()))
         with self._reserved_data_filenames_lock:
             self._reserved_data_filenames |= set(os.listdir(self._session_dir))
-            for distinguisher in xrange(256):
+            #--@FIX: xrange --> range
+            for distinguisher in range(256):
                 if ext is None:
                     filename = "%s_%d" % (title, distinguisher)
                 else:
@@ -553,7 +558,7 @@ class Experiment(object):
             # self._root_executor.enter(clock.now() + 0.25)
 
             # kivy main loop
-            from main import SmileApp
+            from .main import SmileApp
             self._app = SmileApp(self)
             self._app.run()
 

--- a/smile/freekey.py
+++ b/smile/freekey.py
@@ -8,15 +8,16 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
-from keyboard import KeyPress
-from state import Loop, If, Elif, Else, Subroutine
-from state import UntilDone, Wait, ResetClock
-from ref import Ref
-from clock import clock
-from video import Label
+from .keyboard import KeyPress
+from .state import Loop, If, Elif, Else, Subroutine
+from .state import UntilDone, Wait, ResetClock
+from .ref import Ref
+from .clock import clock
+from .video import Label
 
 # set the allowable keys (A-Z)
-asciiplus = [str(unichr(i)) for i in range(65,65+26)]
+#@FIX: unichr -> chr
+asciiplus = [str(chr(i)) for i in range(65,65+26)]
 asciiplus += ['ENTER','BACKSPACE','SPACEBAR']
 asciiplus += ['%d'%i for i in range(10)]
 
@@ -172,9 +173,9 @@ def FreeKey(self, lbl, max_duration=10.0, max_resp=100, base_time=None):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import Wait, Debug
-    from video import Label
+    from .experiment import Experiment
+    from .state import Wait, Debug
+    from .video import Label
 
     exp = Experiment()
 

--- a/smile/grating.py
+++ b/smile/grating.py
@@ -5,7 +5,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from video import WidgetState
+from .video import WidgetState
 from kivy.uix.widget import Widget
 from kivy.properties import NumericProperty, ListProperty, StringProperty
 from kivy.graphics import Rectangle, BindTexture, Callback
@@ -15,6 +15,9 @@ from kivy.graphics.opengl import GL_ONE_MINUS_SRC_ALPHA
 from kivy.graphics.opengl import GL_ONE_MINUS_DST_ALPHA
 import math
 from itertools import chain
+
+#@FIX: import six
+import six
 
 
 # cache so we don't regenerate masks
@@ -220,7 +223,9 @@ class Grating(Widget):
         grating_buf = list(chain.from_iterable([self._calc_color(x)
                                                 for x in range(self._period)]))
         # make an array from the buffer
-        grating_arr = b''.join(map(chr, grating_buf))
+        #@FIX: changed
+        #grating_arr = b''.join(list(map(chr, grating_buf)))
+        grating_arr = b''.join(list(map(lambda x: six.int2byte(x), grating_buf)))
 
         # blit the array to the texture
         self._texture.blit_buffer(grating_arr, colorfmt='rgb',
@@ -241,8 +246,8 @@ class Grating(Widget):
 
         # creation of texture, half the width and height, will be reflected to
         # completely cover the grating texture
-        self._mask_texture = Texture.create(size=(self.width / 2,
-                                                  self.height / 2),
+        self._mask_texture = Texture.create(size=(self.width // 2,
+                                                  self.height // 2),
                                             colorfmt='rgba',
                                             bufferfmt='ubyte')
 
@@ -261,28 +266,31 @@ class Grating(Widget):
                 mask_buf =\
                     list(chain.from_iterable([
                         self._calc_gaussian_mask(rx, ry)
-                        for rx in range(self.width / 2)
-                        for ry in range(self.height / 2)]))
+                        #@FIX: changed / to //
+                        for rx in range(self.width // 2)
+                        for ry in range(self.height // 2)]))
             elif self.envelope[0].lower() == 'l':
                 mask_buf =\
                     list(chain.from_iterable([
                         self._calc_linear_mask(rx, ry)
-                        for rx in range(self.width / 2)
-                        for ry in range(self.height / 2)]))
+                        for rx in range(self.width // 2)
+                        for ry in range(self.height // 2)]))
             elif self.envelope[0].lower() == 'c':
                 mask_buf =\
                     list(chain.from_iterable([
                         self._calc_circular_mask(rx, ry)
-                        for rx in range(self.width / 2)
-                        for ry in range(self.height / 2)]))
+                        for rx in range(self.width // 2)
+                        for ry in range(self.height // 2)]))
             else:
                 mask_buf =\
                     list(chain.from_iterable([
                         self._calc_undefined_mask(rx, ry)
-                        for rx in range(self.width / 2)
-                        for ry in range(self.height / 2)]))
+                        for rx in range(self.width // 2)
+                        for ry in range(self.height // 2)]))
             # turn into an array
-            mask_arr = b''.join(map(chr, mask_buf))
+            #@FIX: updated byte
+            #mask_arr = b''.join(map(chr, mask_buf))
+            mask_arr = b''.join(list(map(lambda x: six.int2byte(x), mask_buf)))
             # print mask_arr
             # add it to the cache
             _mask_cache[mask_id] = mask_arr
@@ -313,10 +321,10 @@ class Grating(Widget):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import UntilDone, Wait, Parallel, Serial
-    from keyboard import KeyPress
-    from video import Label
+    from .experiment import Experiment
+    from .state import UntilDone, Wait, Parallel, Serial
+    from .keyboard import KeyPress
+    from .video import Label
 
     exp = Experiment(background_color="#4F33FF")
 

--- a/smile/keyboard.py
+++ b/smile/keyboard.py
@@ -9,11 +9,11 @@
 
 import os.path, os
 
-from state import CallbackState
-from ref import val, NotAvailable
-from clock import clock
-from experiment import Experiment
-from log import LogWriter, log2csv
+from .state import CallbackState
+from .ref import val, NotAvailable
+from .clock import clock
+from .experiment import Experiment
+from .log import LogWriter, log2csv
 
 
 def Key(name):
@@ -279,8 +279,8 @@ class KeyRecord(KeyState):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import Wait, Debug, Loop, UntilDone, Log, Meanwhile
+    from .experiment import Experiment
+    from .state import Wait, Debug, Loop, UntilDone, Log, Meanwhile
 
     exp = Experiment()
     with Meanwhile():

--- a/smile/lsl.py
+++ b/smile/lsl.py
@@ -7,10 +7,10 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from state import CallbackState, Wait, Parallel, Loop
-from video import Label
-from clock import clock
-from pylsl import StreamInfo, StreamOutlet
+from .state import CallbackState, Wait, Parallel, Loop
+from .video import Label
+from .clock import clock
+from .pylsl import StreamInfo, StreamOutlet
 
 _lsl_outlets = {}
 
@@ -138,7 +138,7 @@ class LSLPush(CallbackState):
 
 if __name__ == "__main__":
 
-    from experiment import Experiment
+    from .experiment import Experiment
 
     exp = Experiment()
 

--- a/smile/main.py
+++ b/smile/main.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 import os
 
 # kivy imports
-import kivy_overrides
+import smile.kivy_overrides as kivy_overrides
 import kivy
 import kivy.base
 from kivy.app import App
@@ -32,9 +32,9 @@ from kivy.utils import platform
 import kivy.clock
 
 # local imports
-from event import event_time
-from clock import clock
-from video import normalize_color_spec
+from .event import event_time
+from .clock import clock
+from .video import normalize_color_spec
 
 
 _kivy_clock = kivy.clock.Clock
@@ -365,8 +365,9 @@ class SmileApp(App):
         if block:
             # draw a transparent point
             # position
-            glVertexAttribPointer(0, 2, GL_INT, GL_FALSE, 0,
-                                  "\x00\x00\x00\x0a\x00\x00\x00\x0a")
+            #@FIX: changed the pointer value to a 0 for testing
+            glVertexAttribPointer(0, 2, GL_INT, GL_FALSE, 0,0)
+                                  #"\x00\x00\x00\x0a\x00\x00\x00\x0a")
             # color
             glVertexAttrib4f(3, 0.0, 0.0, 0.0, 0.0)
             glDrawArrays(GL_POINTS, 0, 1)

--- a/smile/mouse.py
+++ b/smile/mouse.py
@@ -11,14 +11,14 @@ from __future__ import print_function
 import operator
 import os
 
-import kivy_overrides
+import smile.kivy_overrides as kivy_overrides
 import kivy.graphics
 from kivy.core.image import Image
 
-from state import CallbackState, Record
-from ref import Ref, val, NotAvailable
-from experiment import Experiment
-from video import VisualState
+from .state import CallbackState, Record
+from .ref import Ref, val, NotAvailable
+from .experiment import Experiment
+from .video import VisualState
 
 
 def MouseWithin(widget):
@@ -370,8 +370,8 @@ class MousePress(CallbackState):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import Wait, Debug, Loop, Meanwhile, Record, Log, Parallel
+    from .experiment import Experiment
+    from .state import Wait, Debug, Loop, Meanwhile, Record, Log, Parallel
 
     def print_dt(state, *args):
         print(args)

--- a/smile/moving_dots.py
+++ b/smile/moving_dots.py
@@ -4,7 +4,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-from video import WidgetState
+from .video import WidgetState
 from kivy.uix.widget import Widget
 from kivy.clock import Clock
 from kivy.graphics import Color, Point
@@ -91,8 +91,11 @@ class Dot(object):
         self.total_time = random_variance(self.lifespan,
                                           self.lifespan_variance)
 
+class BlackHole(object):
+    def __init__(self, **kwargs):
+        super(BlackHole, self).__init__()
 
-class _MovingDotsWidget(Widget):
+class _MovingDotsWidget(Widget, BlackHole):
     motion_props = ListProperty([{}])
     num_dots = NumericProperty(100)
     scale = NumericProperty(4.0)
@@ -136,10 +139,10 @@ class _MovingDotsWidget(Widget):
             num_coh = int(self.num_dots * current_params['coherence'])
             tot_coh += num_coh
             self.__dots.extend([Dot(**current_params)
-                                for i in xrange(num_coh)])
-
+                                for i in range(num_coh)])
         # calc the number random coh
         num_rand = self.num_dots - tot_coh
+        print("num_rand", num_rand)
         if num_rand < 0:
             raise ValueError('Total coherence must be less than 1.0.')
 
@@ -150,7 +153,7 @@ class _MovingDotsWidget(Widget):
             current_params['direction'] = 0.0
             current_params['direction_variance'] = 360
             self.__dots.extend([Dot(**current_params)
-                                for i in xrange(num_rand)])
+                                for i in range(num_rand)])
 
         self.bind(motion_props=self.callback_motion_props)
 
@@ -189,6 +192,8 @@ class _MovingDotsWidget(Widget):
             num_coh = int(self.num_dots * mprop['coherence'])
             # Loop through that many dots and update their motion properties
             for i in range(tot_coh, tot_coh + num_coh):
+                print("i: ", i)
+                
                 self.__dots[i].direction = current_params['direction']
                 self.__dots[i].direction_variance = current_params['direction_variance']
                 self.__dots[i].speed = current_params['speed']
@@ -197,11 +202,14 @@ class _MovingDotsWidget(Widget):
                 self.__dots[i].lifespan_variance = current_params['lifespan_variance']
 
             tot_coh += num_coh
-
         # For all remaining dots, give them a 0 direction and 360 direction
         # variance. Keep all remaining props as the default params
+        print("tot_coh", tot_coh)
+        print("self.num_dots: ", self.num_dots)
+        print("__dots", len(self.__dots))
         if tot_coh < self.num_dots:
             for i in range(tot_coh, self.num_dots):
+                
                 self.__dots[i].direction = 0
                 self.__dots[i].direction_variance = 360
                 self.__dots[i].speed = default_params['speed']
@@ -292,9 +300,9 @@ class MovingDots(WidgetState.wrap(_MovingDotsWidget)):
 
 if __name__ == '__main__':
 
-    from experiment import Experiment
-    from state import UntilDone, Meanwhile, Wait, Loop, Debug
-    from keyboard import KeyPress
+    from .experiment import Experiment
+    from .state import UntilDone, Meanwhile, Wait, Loop, Debug
+    from .keyboard import KeyPress
 
     # A testing set to show all the different things you can change when
     # setting motion_props during run-time.
@@ -309,7 +317,7 @@ if __name__ == '__main__':
                      "direction_variance": 10, "speed":400,
                      "speed_variance":200},]
                   ]
-    exp = Experiment(background_color=("purple", .3))
+    exp = Experiment(background_color=("purple", .3), debug=True)
 
     Wait(.5)
 

--- a/smile/pulse.py
+++ b/smile/pulse.py
@@ -8,10 +8,10 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import sys
-from state import Wait, State, Loop, Done, Log, Subroutine
-from clock import clock
-from event import event_time
-from ref import NotAvailable
+from smile.state import Wait, State, Loop, Done, Log, Subroutine
+from smile.clock import clock
+from smile.event import event_time
+from smile.ref import NotAvailable
 
 # Interface Class for Docstrings
 class PulseInterface(object):
@@ -351,8 +351,8 @@ def JitteredPulses(self, code=1, width=0.010, port=0,
 
 
 if __name__ == '__main__':
-    from experiment import Experiment
-    from state import Meanwhile, Debug
+    from .experiment import Experiment
+    from .state import Meanwhile, Debug
 
     # set up default experiment
     exp = Experiment()

--- a/smile/questionnaire.py
+++ b/smile/questionnaire.py
@@ -7,12 +7,12 @@
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from video import (WidgetState, Label,
+from .video import (WidgetState, Label,
                    ToggleButton, FloatLayout, ButtonPress,
                    Button, Rectangle, TextInput, Slider)
-from state import (Loop, Parallel, If, Elif, Else, Serial,
+from .state import (Loop, Parallel, If, Elif, Else, Serial,
                    Func, UntilDone, Log, Subroutine,Debug)
-from ref import Ref
+from .ref import Ref
 import kivy.uix.scrollview
 import csv
 ScrollView = WidgetState.wrap(kivy.uix.scrollview.ScrollView)
@@ -680,7 +680,7 @@ def Questionnaire(self,
 
 
 if __name__ == "__main__":
-    from mouse import MouseCursor
+    from .mouse import MouseCursor
     bob = [{'type': "TITLE",
             'question': "SMILE QUESTIONNAIRE"},
            {'type': "LI",
@@ -750,7 +750,7 @@ if __name__ == "__main__":
             'ans': ['10', '12', '15', '20'],
             'group_id': 'second_li_question'}]
 
-    from experiment import Experiment
+    from .experiment import Experiment
     exp = Experiment()
     with Parallel():
         tt = Questionnaire(loq=bob,

--- a/smile/ref.py
+++ b/smile/ref.py
@@ -10,6 +10,9 @@
 import random
 import operator
 
+#@FIX: added import for apply
+#from past.builtins import apply
+
 class NotAvailable(object):
     """Special value for indicating a variable is not available yet.
 
@@ -21,7 +24,8 @@ class NotAvailable(object):
     def __repr__(self):
         return "NotAvailable"
 
-    def __nonzero__(self):
+    #@FIX: changed nonzero to bool
+    def __bool__(self):
         return False
 
 # make a single instance used everywhere
@@ -33,6 +37,17 @@ class NotAvailableError(ValueError):
 def pass_thru(obj):
     """Returns its only argument. Needed to delay the evaluation of a variable."""
     return obj
+
+#@FIX: _apply function to replace apply()
+def _apply(function, *pargs, **kwargs):
+    
+    #@IMPORTANT: may need to check this again. 
+    if len(kwargs)==0:
+        return function(pargs)
+    elif kwargs == None:
+        return function(pargs)
+    else:
+        return function(pargs, kwargs)
 
 class Ref(object):
     """Delayed function call.
@@ -102,10 +117,11 @@ class Ref(object):
                 # override our cache state
                 self.use_cache = False
                 break
-
+    #@FIX: added list() to map(repr, self.pargs)
+    #@FIX: imported numpy and added np.array() to list()
     def __repr__(self):
         return "Ref(%s)" % ", ".join([repr(self.func)] +
-                                     map(repr, self.pargs) +
+                                     list(map(repr, self.pargs)) +
                                      ["%s=%r" % (name, value) for
                                       name, value in
                                       self.kwargs.items()])
@@ -194,13 +210,13 @@ class Ref(object):
         if self.use_cache:
             self.cache_value = value
             self.cache_valid = True
-
+        #print("eval: ", value)
         return value
 
     def add_change_callback(self, func, *pargs, **kwargs):
         """Add callback that's called when this value changes.
         """
-        #print "add_change_callback %s, %r, %r, %r" % (self, func, pargs, kwargs)
+        #print("add_change_callback %s, %r, %r, %r" % (self, func, pargs, kwargs))
         # if this is the first callback
         if not len(self.change_callbacks):
             # set up dependency callbacks
@@ -234,8 +250,12 @@ class Ref(object):
             func(*pargs, **dict(kwargs))
 
     # delayed operators...
+    #@FIX: changed apply to _apply because python3 abandoned apply() :( 
+    #@FIX: added import
     def __call__(self, *pargs, **kwargs):
-        return Ref(apply, self, pargs, kwargs)
+        #print(self, pargs, kwargs)
+        #return Ref(apply, self, pargs, kwargs)
+        return Ref(_apply, self, pargs, kwargs)
 
     def __setitem__(self, index, value):
         if self._parent_state is None:
@@ -245,6 +265,10 @@ class Ref(object):
         return self._parent_state.attribute_update_state(name,
                                                          value,
                                                          index=index)
+    #@FIX: Added __hash__
+    #__hash__=object.__hash__
+    def __hash__(self):
+        return object.__hash__(self)
 
     def __getitem__(self, index):
         return Ref(operator.getitem, self, index)
@@ -340,6 +364,7 @@ def shuffle(iterable):
     return Ref(_shuffle, iterable, use_cache=False)
 
 def val(obj):
+    #print(obj)
     try:
         # handle all types of Refs
         if isinstance(obj, Ref):
@@ -387,64 +412,64 @@ if __name__ == '__main__':
 
     import math
     x = [0.0]
-    r = Ref(math.cos, Ref.getitem(x, 0))
-    print(x[0], val(r))
+    #r = Ref(math.cos, Ref.getitem(x, 0))
+    #print(x[0], val(r))
     x[0] += .5
-    print(x[0], val(r))
+    #print(x[0], val(r))
 
     r = Ref.object(str)(Ref.object(x)[0])
     x[0] += .75
     print(x[0], val(r))
 
-    r = (Ref.object(x)[0] > 0) & (Ref.object(x)[0] < 0)
-    print(x[0], val(r))
-    r = (Ref.object(x)[0] > 0) & (Ref.object(x)[0] >= 0)
-    x[0] -= 10.0
-    print(x[0], val(r))
-
-    y = [7]
-    ry = Ref.object(y)
-    print(y[0], val(ry[0] % 2), val(2 % ry[0]))
-    y[0] = 8
-    print(y[0], val(ry[0] % 2), val(2 % ry[0]))
-
-    class Jubba(object):
-        def __init__(self, val):
-            self.x = val
-
-        def __getitem__(self, index):
-            return Ref.getattr(self, index)
-
-    a = Jubba(5)
-    b = Ref.getattr(a, 'x')
-    br = Ref.object(a).x
-    print(val(b), val(br))
-    a.x += 42.0
-    print(val(b), val(br))
-
-    c = {'y': 6}
-    d = Ref.getitem(c, 'y')
-
-    e = [4, 3, 2]
-    f = Ref.getitem(e, 2)
-
-    g = b+d+f
-    print(val(g))
-
-    a.x = 6
-    print(val(g))
-
-    c['y'] = 7
-    print(val(g))
-
-    e[2] = 3
-    print(val(g))
-
-    x = Jubba([])
-    y = Ref.getitem(x, 'x')
-    print(val(y))
-    y = y + [b]
-    print(val(y))
-    y = y + [d]
-    y = y + [f]
-    print(val(y))
+    '''r = (Ref.object(x)[0] > 0) & (Ref.object(x)[0] < 0)
+                print(x[0], val(r))
+                r = (Ref.object(x)[0] > 0) & (Ref.object(x)[0] >= 0)
+                x[0] -= 10.0
+                print(x[0], val(r))
+            
+                y = [7]
+                ry = Ref.object(y)
+                print(y[0], val(ry[0] % 2), val(2 % ry[0]))
+                y[0] = 8
+                print(y[0], val(ry[0] % 2), val(2 % ry[0]))
+            
+                class Jubba(object):
+                    def __init__(self, val):
+                        self.x = val
+            
+                    def __getitem__(self, index):
+                        return Ref.getattr(self, index)
+            
+                a = Jubba(5)
+                b = Ref.getattr(a, 'x')
+                br = Ref.object(a).x
+                print(val(b), val(br))
+                a.x += 42.0
+                print(val(b), val(br))
+            
+                c = {'y': 6}
+                d = Ref.getitem(c, 'y')
+            
+                e = [4, 3, 2]
+                f = Ref.getitem(e, 2)
+            
+                g = b+d+f
+                print(val(g))
+            
+                a.x = 6
+                print(val(g))
+            
+                c['y'] = 7
+                print(val(g))
+            
+                e[2] = 3
+                print(val(g))
+            
+                x = Jubba([])
+                y = Ref.getitem(x, 'x')
+                print(val(y))
+                y = y + [b]
+                print(val(y))
+                y = y + [d]
+                y = y + [f]
+                print(val(y))'''

--- a/smile/state.py
+++ b/smile/state.py
@@ -16,12 +16,12 @@ import inspect
 import weakref
 import os.path, os
 
-import kivy_overrides
-import ref
-from ref import Ref, val, NotAvailable, NotAvailableError
+import smile.kivy_overrides as kivy_overrides
+import smile.ref as ref
+from .ref import Ref, val, NotAvailable, NotAvailableError
 #from utils import rindex, get_class_name
-from log import LogWriter, log2csv
-from clock import clock
+from .log import LogWriter, log2csv
+from .clock import clock
 
 
 class StateConstructionError(RuntimeError):
@@ -111,9 +111,13 @@ class StateClass(type):
             cls._builder_class = type(cls.__name__ + "Builder",
                                       (StateBuilder, cls),
                                       {"_state_class": cls})
+    #def __new__(cls, *pargs, **kwargs):
+    #    return super(StateClass, cls).__new__(cls, *pargs, **kwargs)
 
 
-class State(object):
+#class State(object):
+#-- @FIX: python3 __metaclass__ changed
+class State(object, metaclass=StateClass):
     """Base State object for the hierarchical state machine.
 
     This class contains all of the calls that are required of a state
@@ -166,20 +170,14 @@ class State(object):
     """
 
     # Apply the StateClass metaclass
-    __metaclass__ = StateClass
-
+    #__metaclass__ = StateClass
     def __new__(cls, *pargs, **kwargs):
-        # Pull out the use_state_class argument
         use_state_class = kwargs.pop("use_state_class", False)
-
         if use_state_class or issubclass(cls, StateBuilder):
-            # If this is already a StateBuilder or if we got the
-            # use_state_class flag, create the object as normal.
-            return super(State, cls).__new__(cls, *pargs, **kwargs)
+            #@FIX: deleted *pargs, **kwargs
+            return super(State, cls).__new__(cls)
         else:
-            # Otherwise, instantiate with the StateBuilder mixin instead.
-            return cls._builder_class.__new__(cls._builder_class,
-                                              *pargs, **kwargs)
+            return cls._builder_class.__new__(cls._builder_class, *pargs, **kwargs)
 
     def __init__(self, parent=None, duration=None, save_log=True, name=None,
                  blocking=True):
@@ -244,7 +242,7 @@ class State(object):
         # Record which source file and line number this constructor was called
         # from.
         # Associate this state with the most recently instantiated Experiment.
-        from experiment import Experiment
+        from .experiment import Experiment
         try:
             self._exp = Experiment._last_instance()
             self._debug = self._exp._debug
@@ -641,7 +639,7 @@ class State(object):
 
         # if we don't have the exp reference, get it now
         if self._exp is None:
-            from experiment import Experiment
+            from .experiment import Experiment
             self._exp = Experiment._last_instance()
 
         # evaluate the '_init_' Refs...
@@ -1283,7 +1281,7 @@ def _ParallelWithPrevious(name=None, parallel_name=None, blocking=True):
 
     """
     # get the exp reference
-    from experiment import Experiment
+    from .experiment import Experiment
     try:
         exp = Experiment._last_instance()
     except AttributeError:
@@ -1407,7 +1405,9 @@ class SequentialState(ParentState):
         try:
             # clone the children as they come, so just clone the first
             self.__current_child = (
-                self.__child_iterator.next()._clone(self))
+                #-- @FIX: python3 .next() changed
+                #self.__child_iterator.next()._clone(self))
+                next(self.__child_iterator)._clone(self))
             # schedule the child based on the current start time
             clock.schedule(partial(self.__current_child.enter,
                                    self._start_time))
@@ -1439,7 +1439,9 @@ class SequentialState(ParentState):
             try:
                 # clone the next child and schedule it
                 self.__current_child = (
-                    self.__child_iterator.next()._clone(self))
+                    #-- @FIX: Python3 .next() changed
+                    #self.__child_iterator.next()._clone(self))
+                    next(self.__child_iterator)._clone(self))
                 clock.schedule(partial(self.__current_child.enter, next_time))
             except StopIteration:
                 # there are no more children, so set our end time and leave
@@ -1794,7 +1796,7 @@ def Else(name="ELSE BODY"):
     """Returns the else clause of the preceding If state. See *If*
     """
     # get the exp reference
-    from experiment import Experiment
+    from .experiment import Experiment
     try:
         exp = Experiment._last_instance()
     except AttributeError:
@@ -1961,7 +1963,8 @@ class Loop(SequentialState):
             else:
                 count = len(self._iterable)
 
-            for i in xrange(count):
+            #--@FIX: xrange to range --
+            for i in range(count):
                 yield i
 
     def _get_child_iterator(self):
@@ -2038,6 +2041,7 @@ class Record(State):
 
         self.__refs = kwargs
         self.__triggers = triggers
+        #@FIX: changed "none" to "None"
         self.__log_filename = None
         self.__log_writer = None
 
@@ -2480,6 +2484,7 @@ class Wait(State):
             self._until_value = self.__until.eval()
         except NotAvailableError:
             self._until_value = NotAvailable
+        #print(self._until_value, NotAvailable, type(NotAvailable), type(self._until_value))
         if self._until_value:
             clock.schedule(partial(self.cancel, self._start_time))
         else:
@@ -2773,7 +2778,7 @@ class PrintTraceback(CallbackState):
 
 
 if __name__ == '__main__':
-    from experiment import Experiment
+    from .experiment import Experiment
 
     def print_actual_duration(target):
         print(val(target.end_time - target.start_time))
@@ -2812,7 +2817,7 @@ if __name__ == '__main__':
     with Loop(5) as loop:
         Log(a=1, b=2, c=loop.i, name="aaa")
     Log({"q": loop.i, "w": loop.i}, x=4, y=2, z=1, name="bbb")
-    Log([{"q": loop.i, "w": n} for n in xrange(5)], x=4, y=2, z=1, name="ccc")
+    Log([{"q": loop.i, "w": n} for n in range(5)], x=4, y=2, z=1, name="ccc")
     #Log("sdfsd")  # This should cause an error
 
     exp.for_the_thing = 3


### PR DESCRIPTION
THIS WILL BREAK PYTHON 2 

SMILE Fixes 

Notes
        - Tried to make this as comprehensive as possible, but may have missed some of the changes I made 
	- check substitute `apply()` function in ref.py
        - check blackhole fix in video.py
        - imports
################################################################################ All Applicable Files
Python 2.7: `from x import y`
Python 3+: `from .x import y`

Python 2.7: `import x`
Python 3+: `import smile.x`

Note:
    - Cannot run files inside the smile folder due to the import change
        - i.e. `python ref.py`
    - Can only run files outside of the smile folder (the experiment files)
        - i.e. `python reinstateMain.py`

    - To run files inside the smile folder --> undo all import changes in all smile files. 
################################################################################
freekey.py
Line 19: changed unichr to chr
################################################################################
ref.py ##########

**** IMPORTANT ****
**** substitute `apply()` function ****
Python 2.7: global function `apply()`
Python 3+: `apply()`* doesn't exist anymore :(
Line 239: `return Ref(apply, self, pargs, kwargs)`
Line 37: added an _apply function --> may have to check this again, fix probably isn't the most effective fix
    - *option to do `from past.builtins import apply` --> but causes errors

Python 2.7: implicit hashing
Python 3+: "A class that overrides` __eq__()` and does not define `__hash__() `will have its `__hash__()` implicitly set to None. When the `__hash__()` method of a class is None, instances of the class will raise an appropriate TypeError when a program attempts to retrieve their hash value, and will also be correctly identified as unhashable when checking `isinstance(obj, collections.Hashable)`."
	https://docs.python.org/3/reference/datamodel.html#object.__hash
         (ref overrides eq but does not define hash, therefore hash was set to None)
	- Running: python video.py
	- Error: 
	File "C:\Users\limhe\OneDrive\School\UVa\CompAnalyLab\smile-master\smile - Copy\ref.py", line 223, in add_change_callback
     self.change_callbacks.add((func, pargs, tuple(kwargs.items())))
 	TypeError: unhashable type: 'Ref'
Line 263: Defined the hash function:
```
    def __hash__(self):
        return object.__hash__(self)
```

Python 2.7: `map()` returns list
Python 3+: `map()` returns iterator
Line 112: `map(repr, self.pargs)` --> `list(map(repr, self.pargs))`

Python 2.7:` __nonezero__`
Python 3+: `__bool__`
Line 28: `def __nonzero__(self)`

################################################################################
state.py ##########

Line 2066 `self.__log_filename = none`
changed "none" to "None"

Python 2.7: `xrange`
Python 3+: `range`

Python 2.7: `---.next()`
Python 3+: `next(---)`
Line 1410 - `self.__child_iterator.next()._clone(self))`
Line 1442 `self.__child_iterator.next()._clone(self))`

Python 2.7: `__metaclass__ = form`
Python 3+: `class name(object, metaclass=form)`
Line 170` __metaclass__ = StateClass`

Python 2.7: `xrange`
Python 3+: `range`
*Slight differences in range implementa
tion but shouldn't affect SMILE
Line 463 `for distinguisher in xrange(256)`

Python 2.7:` .__new__(multiple arguments)`
Python 3.6: `__new__(one argument) (?)`
*not sure about this one, need to double check
Line 181 `return super(State, cls).__new__(cls, *pargs, **kwargs)`

################################################################################
video.py ##########

Python 2.7: '/' worked as integer division (returns an int)
Python 3+: '/' works as true division (returns a float)
Line 3528: exp.screen.width / 4, exp.screen.height / 8
	changed to "//", '/' in python2 is the equivalent to '//' in python3

Python 2.7: `dict.keys()` returns the keys
Python 3+: `dict.keys()` returns a dictionary view: dict_keys[(keys)]
Line 341 `self._constructor_param_names = param.keys()` --> `list(param)` returns keys
Line 720 `pos_prope = (xy_pos_props.keys() + ...)`

**** IMPORTANT ****
**** BlackHole Fix ****
** Need to check this fix **
Line 27: BlackHole Class
    - Python 2.7: Passing excess keyword arguments caused a deprecated warning 
        - You can see this by running "python -Wdefault file.py"
    - Python 3+: Changed deprecated warning to an error
        - Addition of BlackHole class takes up excess parameters 
```
class BlackHole(object):
    def __init__(self, **kwargs):
        super(BlackHole, self).__init__()
```

Line 36: Added BlackHole class to base inheritance
    - `kivy.uix.widget.Widget.__bases__ = (WidgetBase, BlackHole,)`

Line 1577 - 1587: 
    - Added BlackHole class to base inheritance: 
        - `kivy.uix.progressbar.ProgressBar.__bases__ = (kivy.uix.widget.Widget, BlackHole,)`
        - `kivy.uix.label.Label.__bases__ = (kivy.uix.widget.Widget, BlackHole,)`
        - `kivy.uix.textinput.TextInput.__bases__ = (kivy.uix.behaviors.FocusBehavior, kivy.uix.widget.Widget, BlackHole,)`

Line 3134: Added BlackHole class to base inheritance:
    - `kivy.uix.image.Image.__bases__ = (kivy.uix.widget.Widget, BlackHole,)
`

################################################################################
main.py ##########

Line 369 glVertexAttriPointer(0,2, GL_INT, GL_FALSE, 0, "\x00\x00\x00\x0a\x00\x00\x00\x0a")
Received error: File "C:\Users\limhe\OneDrive\School\UVa\CompAnalyLab\smile-master\smile - Copy\main.py", line 136, in _on_start
     self.do_flip(block=True)
   File "C:\Users\limhe\OneDrive\School\UVa\CompAnalyLab\smile-master\smile - Copy\main.py", line 370, in do_flip
     "\x00\x00\x00\x0a\x00\x00\x00\x0a")
   File "kivy\graphics\opengl.pyx", line 1545, in kivy.graphics.opengl.glVertexAttribPointer (kivy\graphics\opengl.c:19612)
 TypeError: Argument 'data' has incorrect type (expected bytes or int).

- Changed "\x00 ..." to 0

################################################################################
 StartScreen_2.py ##########

 removed the **kwargs argument from `__init__`
 moving_dots.py
 removed **kwargs in `super(type(self), self).__init__(**kwargs)` in `class _MovingDotsWidget(Widget)`

changed xrange to range
	- starting dots are different
	- able to run the program
	- dots disappears and exits after pressing 'shift' key

################################################################################
misc. changes to experiment files: ##########
	- xrange -> range
	- .next() -> next()
	- dict.keys() -> list(dict)
	- print statements

reinstateMain.py
	- Line 43: / to //
	- Line 68: / to //

Common Errors:
	- TypeError: unsupported operand type(s) for /: 'Ref' and 'int'
		- Likely trying to do division --> change / to // 

################################################################################ Useful Links and things
https://stackoverflow.com/questions/4015417/python-class-inherits-object
	- classic style vs new style 
	- python 2 vs python 3
https://stackoverflow.com/questions/38397610/how-to-change-the-base-class-in-python
https://docs.python.org/3.0/whatsnew/3.0.html
https://github.com/kivy/kivy/issues/5663
	- BlackHole Fix
https://stackoverflow.com/questions/395982/metaclass-new-cls-and-super-what-is-the-mechanism-exactly
	- super comprehensive explanation
https://stackoverflow.com/questions/19277399/why-does-object-new-work-differently-in-these-three-cases
	- "__init__() complains about excess arguments unless __new__() is overridden and __init__() is not overridden (IOW, if __init__() is overridden or __new__() is not overridden); symmetrically, __new__() complains about excess arguments unless  __init__() is overridden and __new__() is not overridden (IOW, if __new__() is overridden or __init__() is not overridden)."
	- "However, for backwards compatibility, this breaks too much code. Therefore, in 2.6, we'll warn about excess arguments when both methods are overridden; for all other cases we'll use the above rules."
https://stackoverflow.com/questions/100003/what-are-metaclasses-in-python

################################################################################
################################################################################
