### PR TITLE
Fix looping w lists and conditionals

### DIFF
--- a/smile/state.py
+++ b/smile/state.py
@@ -1970,6 +1970,9 @@ class Loop(SequentialState):
                 count = len(self._iterable)
 
             for i in range(count):
+                self._outcome = val(self._cond)
+                if not self._outcome:
+                    break
                 yield i
 
     def _get_child_iterator(self):

--- a/smile/state.py
+++ b/smile/state.py
@@ -1932,9 +1932,9 @@ class Loop(SequentialState):
 
         if shuffle:
             # Due to namespace issues, ref.shuffle is imported as ref_shuffle
-            self._init_iterable = ref_shuffle(iterable)
+            self._iterable = ref_shuffle(iterable)
         else:
-            self._init_iterable = iterable
+            self._iterable = iterable
         self._cond = conditional
         self._outcome = True
 

--- a/smile/state.py
+++ b/smile/state.py
@@ -1932,9 +1932,9 @@ class Loop(SequentialState):
 
         if shuffle:
             # Due to namespace issues, ref.shuffle is imported as ref_shuffle
-            self._iterable = ref_shuffle(iterable)
+            self._init_iterable = ref_shuffle(iterable)
         else:
-            self._iterable = iterable
+            self._init_iterable = iterable
         self._cond = conditional
         self._outcome = True
 


### PR DESCRIPTION
Fixes the issue Austin was having with provided Loop an iterable and a conditional, and the loop continuing past when the conditional became False.

~~Also noticed the iterable was being assigned to `self._init_iterable` when `_init_iterable` is not referenced anywhere else in smile, so changed the assignment to `self._iterable` which is how the iterable is referenced throughout the Loop class.~~ Read comment for `_init_iterable` info.

**Test Code**

```
# load in smile states
from smile.common import *

# create an experiment instance
exp = Experiment(debug=True, show_splash=False)

list = [1, 2, 3, 4, 5]
exp.cond = True 

# Should stop on cond False
with Loop(iterable=list, conditional=exp.cond) as num:
    Debug(msg = "---------------------------")
    Debug(msg = exp.cond)
    Debug(msg = num.current)
    with If(num.current == 3):
        exp.cond = False
        Debug(msg = "I THINK THIS IS A THREE")
    Debug(msg = exp.cond)
    Debug(msg = "---------------------------")
    

exp.run()
```