### PR TITLE
Update log reading to allow reading python2 pickled slogs

### DIFF
--- a/smile/log.py
+++ b/smile/log.py
@@ -81,7 +81,7 @@ class LogReader(object):
         self._append_columns = append_columns
 
         # set up the unpickler
-        self._unpickler = pickle.Unpickler(self._file)
+        self._unpickler = pickle.Unpickler(self._file, encoding="latin1")
 
     def read_record(self):
         """Returns a dicitionary with the field names as keys.


### PR DESCRIPTION
Change Unpickler encoding to 'latin1'. This should only change things when reading in slog files encoded with python 2.

I had trouble confirming this rigorously and figured someone here may know of the top of their head. This fixed my issue in reading in an old experiment, however, I haven't check if it works for reading in new experiments (and I wasn't sure where to find a new experiment to test on).

